### PR TITLE
Fix CredentialTask mapping type to restore build

### DIFF
--- a/lib/store.ts
+++ b/lib/store.ts
@@ -260,7 +260,7 @@ export const useNurseStore = create<NurseStore>((set, get) => ({
     set((state) => {
       let gainedXp = 0;
       let questIncrement: string | null = null;
-      const tasks = state.tasks.map((task) => {
+      const tasks = state.tasks.map((task): CredentialTask => {
         if (task.id !== taskId) return task;
         if (task.status === "to-collect") {
           return {


### PR DESCRIPTION
## Summary
- annotate the credential task mapping to ensure the updated tasks array preserves the CredentialTask type
- unblock the production build by keeping task status updates within the expected TaskStatus union

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6cb2608c483289e8095e219f8807c